### PR TITLE
Use pre-determined descriptor length as minimum

### DIFF
--- a/relic_usb_host_descriptor_parser.py
+++ b/relic_usb_host_descriptor_parser.py
@@ -52,7 +52,7 @@ class Descriptor:
 
     def __init__(self, descriptor: bytearray, length: int = None, descriptor_type: int = None):
         if (
-            (length is not None and len(descriptor) != length)
+            (length is not None and len(descriptor) < length)
             or descriptor[0] != len(descriptor)
             or (descriptor_type is not None and descriptor[1] != descriptor_type)
         ):


### PR DESCRIPTION
I've discovered that some odd devices may report endpoint descriptors with longer lengths. I'm not sure what the extra data is used for, but it was causing `ValueError` exceptions because it did not match the standard sizing. I've instead made the standard descriptor length a minimum to allow for this.

The tested device was a wired PlayStation DUALSHOCK 4 controller which was reporting endpoint descriptors with a length of 9 bytes.