### PR TITLE
Add basic hid descriptor parsing

### DIFF
--- a/examples/usb_host_descriptor_parser_simpletest.py
+++ b/examples/usb_host_descriptor_parser_simpletest.py
@@ -12,6 +12,8 @@ for i, device in enumerate(usb.core.find(find_all=True)):
         print(f"- Configuration {j+1}: {configuration}")
         for k, interface in enumerate(configuration.interfaces):
             print(f"  - Interface {k+1}: {interface}")
+            if interface.hid_descriptor is not None:
+                print(f"    - HID: {interface.hid_descriptor}")
             for l, endpoint in enumerate(interface.endpoints):
                 print(f"    - Endpoints {l+1}: {endpoint}")
     print()


### PR DESCRIPTION
Very basic support for parsing HID reports has been added here just to identify the HID usage type of a device. I plan to add more thorough parsing, but it will likely need to be moved into its own submodule due to the complexity of the task.